### PR TITLE
feat: add deployment annotations for referenced configmaps and secrets

### DIFF
--- a/charts/interop-eks-microservice-chart/README.md
+++ b/charts/interop-eks-microservice-chart/README.md
@@ -13,7 +13,8 @@ The following table lists the configurable parameters of the Interop-eks-microse
 |-----|------|---------|-------------|
 | autoscaling | object | `{"horizontal":{"create":false}}` | Horizontal Pod Autoscaling configuration |
 | autoscaling.horizontal.create | bool | `false` | Enable horizontal pod autoscaling |
-| deployment.enableRolloutAnnotations | bool | `false` | Enable annotation generation for referenced configmaps and secrets |
+| deployment.configmapHash | string | `nil` | Hash of the related ConfigMap |
+| deployment.enableRolloutAnnotations | bool | `false` | Enable annotation generation for referenced configmaps and secrets  |
 | deployment.env | object | `nil` | List of environment variables for a container, specifying a value directly for each named variable |
 | deployment.envFromConfigmaps | object | `nil` | List of environment variables for a container, specifying a key from a Configmap for each named variable (k8s equivalent of envFrom.configMapRef) |
 | deployment.envFromFieldRef | object | `nil` | List of pod fields used as values for environment variablesenvironment variables for a container, specifying a key from a Secret for each named variable (k8s equivalent of env.valueFrom.fieldRef.fieldPath) |
@@ -25,7 +26,7 @@ The following table lists the configurable parameters of the Interop-eks-microse
 | deployment.flywayInitContainer.envFromFieldRef | object | `nil` | List of pod fields used as values for environment variablesenvironment variables for a container, specifying a key from a Secret for each named variable (k8s equivalent of env.valueFrom.fieldRef.fieldPath) |
 | deployment.flywayInitContainer.envFromSecrets | object | `nil` | List of environment variables for a container, specifying a key from a Secret for each named variable (k8s equivalent of envFrom.secretRef) |
 | deployment.flywayInitContainer.migrationsConfigmap | string | `nil` | Configmap with migrations |
-| deployment.flywayInitContainer.resources | object | null | K8s Flyway init container resources requests and limits |
+| deployment.flywayInitContainer.resources | object | null | K8s Flyway init container resources requests and limits. If empty uses the same resources as main container |
 | deployment.flywayInitContainer.version | string | `"8.2.3"` | Flyway container image version |
 | deployment.image | object | `{"digest":null,"imagePullPolicy":"Always","repositoryName":null,"repositoryPrefix":null,"tag":null}` | Microservice image configuration |
 | deployment.image.digest | string | `nil` | Image digest |

--- a/charts/interop-eks-microservice-chart/README.md
+++ b/charts/interop-eks-microservice-chart/README.md
@@ -13,7 +13,7 @@ The following table lists the configurable parameters of the Interop-eks-microse
 |-----|------|---------|-------------|
 | autoscaling | object | `{"horizontal":{"create":false}}` | Horizontal Pod Autoscaling configuration |
 | autoscaling.horizontal.create | bool | `false` | Enable horizontal pod autoscaling |
-| deployment.enableRolloutAnnotations | bool | `false` | Enable annotation generation for referenced configmaps and secrets  |
+| deployment.enableRolloutAnnotations | bool | `false` | Enable annotation generation for referenced configmaps and secrets |
 | deployment.env | object | `nil` | List of environment variables for a container, specifying a value directly for each named variable |
 | deployment.envFromConfigmaps | object | `nil` | List of environment variables for a container, specifying a key from a Configmap for each named variable (k8s equivalent of envFrom.configMapRef) |
 | deployment.envFromFieldRef | object | `nil` | List of pod fields used as values for environment variablesenvironment variables for a container, specifying a key from a Secret for each named variable (k8s equivalent of env.valueFrom.fieldRef.fieldPath) |

--- a/charts/interop-eks-microservice-chart/README.md
+++ b/charts/interop-eks-microservice-chart/README.md
@@ -1,7 +1,7 @@
 
 # interop-eks-microservice-chart
 
-![Version: 1.13.2](https://img.shields.io/badge/Version-1.13.2-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.15.0](https://img.shields.io/badge/Version-1.15.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Helm chart for PagoPa Interop Microservices
 
@@ -13,6 +13,7 @@ The following table lists the configurable parameters of the Interop-eks-microse
 |-----|------|---------|-------------|
 | autoscaling | object | `{"horizontal":{"create":false}}` | Horizontal Pod Autoscaling configuration |
 | autoscaling.horizontal.create | bool | `false` | Enable horizontal pod autoscaling |
+| deployment.enableRolloutAnnotations | bool | `false` | Enable annotation generation for referenced configmaps and secrets  |
 | deployment.env | object | `nil` | List of environment variables for a container, specifying a value directly for each named variable |
 | deployment.envFromConfigmaps | object | `nil` | List of environment variables for a container, specifying a key from a Configmap for each named variable (k8s equivalent of envFrom.configMapRef) |
 | deployment.envFromFieldRef | object | `nil` | List of pod fields used as values for environment variablesenvironment variables for a container, specifying a key from a Secret for each named variable (k8s equivalent of env.valueFrom.fieldRef.fieldPath) |

--- a/charts/interop-eks-microservice-chart/README.md
+++ b/charts/interop-eks-microservice-chart/README.md
@@ -13,7 +13,7 @@ The following table lists the configurable parameters of the Interop-eks-microse
 |-----|------|---------|-------------|
 | autoscaling | object | `{"horizontal":{"create":false}}` | Horizontal Pod Autoscaling configuration |
 | autoscaling.horizontal.create | bool | `false` | Enable horizontal pod autoscaling |
-| deployment.enableRolloutAnnotations | bool | `false` |  |
+| deployment.enableRolloutAnnotations | bool | `false` | Enable annotation generation for referenced configmaps and secrets |
 | deployment.env | object | `nil` | List of environment variables for a container, specifying a value directly for each named variable |
 | deployment.envFromConfigmaps | object | `nil` | List of environment variables for a container, specifying a key from a Configmap for each named variable (k8s equivalent of envFrom.configMapRef) |
 | deployment.envFromFieldRef | object | `nil` | List of pod fields used as values for environment variablesenvironment variables for a container, specifying a key from a Secret for each named variable (k8s equivalent of env.valueFrom.fieldRef.fieldPath) |
@@ -33,7 +33,6 @@ The following table lists the configurable parameters of the Interop-eks-microse
 | deployment.image.repositoryName | string | `nil` | Alternative image name |
 | deployment.image.repositoryPrefix | string | `nil` | Image repository |
 | deployment.image.tag | string | `nil` | Image tag |
-| deployment.metadata | bool | `{"annotations":null,"labels":null}` | Enable annotation generation for referenced configmaps and secrets |
 | deployment.metadata.annotations | object | `nil` | Additional annotations to apply to Deployment metadata |
 | deployment.metadata.labels | object | `nil` | Additional labels to apply to Deployment metadata |
 | deployment.podTemplateMetadata.annotations | object | `nil` | Additional annotations to apply to Pod `spec.template.metadata` |

--- a/charts/interop-eks-microservice-chart/README.md
+++ b/charts/interop-eks-microservice-chart/README.md
@@ -25,7 +25,7 @@ The following table lists the configurable parameters of the Interop-eks-microse
 | deployment.flywayInitContainer.envFromFieldRef | object | `nil` | List of pod fields used as values for environment variablesenvironment variables for a container, specifying a key from a Secret for each named variable (k8s equivalent of env.valueFrom.fieldRef.fieldPath) |
 | deployment.flywayInitContainer.envFromSecrets | object | `nil` | List of environment variables for a container, specifying a key from a Secret for each named variable (k8s equivalent of envFrom.secretRef) |
 | deployment.flywayInitContainer.migrationsConfigmap | string | `nil` | Configmap with migrations |
-| deployment.flywayInitContainer.resources | object | null | K8s Flyway init container resources requests and limits. If empty uses the same resources as main container |
+| deployment.flywayInitContainer.resources | object | null | K8s Flyway init container resources requests and limits |
 | deployment.flywayInitContainer.version | string | `"8.2.3"` | Flyway container image version |
 | deployment.image | object | `{"digest":null,"imagePullPolicy":"Always","repositoryName":null,"repositoryPrefix":null,"tag":null}` | Microservice image configuration |
 | deployment.image.digest | string | `nil` | Image digest |

--- a/charts/interop-eks-microservice-chart/templates/deployment.nodejs.yaml
+++ b/charts/interop-eks-microservice-chart/templates/deployment.nodejs.yaml
@@ -38,28 +38,35 @@ spec:
         digest: {{ .Values.deployment.image.digest | quote }} # Used to force deployment on same image version but different content
         {{- end }}
         
-        # For each configmap and secret referenced by the deployment, execute a lookup to get the resourceVersion and store it in the annotation
+        # For each configmap and secret referenced by the deployment, execute a lookup to get the .metadata.resourceVersion field and store it in an annotation
         # Lookup reference: https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-lookup-function
-        {{- if .Values.deployment.envFromConfigmaps }}
-          {{- range $key, $val := .Values.deployment.envFromConfigmaps }}
-            {{- $configmapAddress := mustRegexSplit "\\." $val 2 }}
-            {{- $configmapName := index $configmapAddress 0 }}
-            {{- $configmap := lookup "v1" "ConfigMap" $.Values.namespace $configmapName }}
-            {{- if $configmap }}
-            configmap/resourceVersion: "{{ $configmapName }}/{{ $configmap.metadata.resourceVersion }}"
-            {{- end }}
-          {{- end }}
+        {{- $processedConfigmaps := dict }} # Map to store the processed configmaps
+        {{- if .Values.deployment.envFromConfigmaps }}  
+        {{- range $key, $val := .Values.deployment.envFromConfigmaps }}
+        {{- $configmapAddress := mustRegexSplit "\\." $val 2 }}
+        {{- $configmapName := index $configmapAddress 0 }}
+        {{- if not (hasKey $processedConfigmaps $configmapName) }}  # Check if the configmap has been processed yet
+        {{- $configmap := lookup "v1" "ConfigMap" $.Values.namespace $configmapName }}
+        {{- if $configmap }}
+        configmap/{{ $configmapName }}/resourceVersion: "{{ $configmapName }}/{{ $configmap.metadata.resourceVersion }}"
+        {{- $_ := set $processedConfigmaps $configmapName "" }}  # Set the configmap as processed
         {{- end }}
-
-        {{- if .Values.deployment.envFromSecrets }}
-          {{- range $key, $val := .Values.deployment.envFromSecrets }}
-            {{- $secretAddress := mustRegexSplit "\\." $val 2 }}
-            {{- $secretName := index $secretAddress 0 }}
-            {{- $secret := lookup "v1" "Secret" $.Values.namespace $secretName }}
-            {{- if $secret }}
-            secret/resourceVersion: "{{ $secretName }}/{{ $secret.metadata.resourceVersion }}"
-            {{- end }}
-          {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- $processedSecrets := dict }} # Map to store the processed secrets
+        {{- if .Values.deployment.envFromSecrets }}  
+        {{- range $key, $val := .Values.deployment.envFromSecrets }}
+        {{- $secretAddress := mustRegexSplit "\\." $val 2 }}
+        {{- $secretName := index $secretAddress 0 }}
+        {{- if not (hasKey $processedSecrets $secretName) }}  # Check if the secret has been processed yet
+        {{- $secret := lookup "v1" "Secret" $.Values.namespace $secretName }}
+        {{- if $secret }}
+        secret/{{ $secretName }}/resourceVersion: "{{ $secretName }}/{{ $secret.metadata.resourceVersion }}"
+        {{- $_ := set $processedSecrets $secretName "" }}  # Set the secret as processed
+        {{- end }}
+        {{- end }}
+        {{- end }}
         {{- end }}
 
     spec:

--- a/charts/interop-eks-microservice-chart/templates/deployment.nodejs.yaml
+++ b/charts/interop-eks-microservice-chart/templates/deployment.nodejs.yaml
@@ -38,7 +38,7 @@ spec:
         digest: {{ .Values.deployment.image.digest | quote }} # Used to force deployment on same image version but different content
         {{- end }}
 
-        {{- if .Values.deployment.envFromConfigmaps }}  
+        {{- if and .Values.deployment .Values.deployment.envFromConfigmaps }}  
         {{- $processedConfigmaps := dict }}
         {{- range $key, $val := .Values.deployment.envFromConfigmaps }}
         {{- $configmapAddress := mustRegexSplit "\\." $val 2 }}
@@ -53,7 +53,7 @@ spec:
         {{- end }}
         {{- end }}
         
-        {{- if .Values.deployment.envFromSecrets }}  
+        {{- if and .Values.deployment .Values.deployment.envFromSecrets }}  
         {{- $processedSecrets := dict }}
         {{- range $key, $val := .Values.deployment.envFromSecrets }}
         {{- $secretAddress := mustRegexSplit "\\." $val 2 }}

--- a/charts/interop-eks-microservice-chart/templates/deployment.nodejs.yaml
+++ b/charts/interop-eks-microservice-chart/templates/deployment.nodejs.yaml
@@ -46,7 +46,7 @@ spec:
         {{- if not (hasKey $processedConfigmaps $configmapName) }}
         {{- $configmap := lookup "v1" "ConfigMap" $.Values.namespace $configmapName }}
         {{- if $configmap }}
-        configmap/{{ $configmapName }}/resourceVersion: {{ $configmapName }}/{{ $configmap.metadata.resourceVersion }}
+        {{ $configmapName }}/configmap.resourceVersion: {{ $configmap.metadata.resourceVersion }}
         {{- $_ := set $processedConfigmaps $configmapName "" }}
         {{- end }}
         {{- end }}
@@ -61,7 +61,7 @@ spec:
         {{- if not (hasKey $processedSecrets $secretName) }}
         {{- $secret := lookup "v1" "Secret" $.Values.namespace $secretName }}
         {{- if $secret }}
-        secret/{{ $secretName }}/resourceVersion: {{ $secretName }}/{{ $secret.metadata.resourceVersion }}
+        {{ $secretName }}/secret.resourceVersion: {{ $secret.metadata.resourceVersion }}
         {{- $_ := set $processedSecrets $secretName "" }}
         {{- end }}
         {{- end }}

--- a/charts/interop-eks-microservice-chart/templates/deployment.nodejs.yaml
+++ b/charts/interop-eks-microservice-chart/templates/deployment.nodejs.yaml
@@ -44,7 +44,7 @@ spec:
         {{- $configmapAddress := mustRegexSplit "\\." $val 2 }}
         {{- $configmapName := index $configmapAddress 0 }}
         {{- if not (hasKey $processedConfigmaps $configmapName) }}
-        {{- $configmap := lookup "v1" "ConfigMap" $.Values.namespace $secretName }}
+        {{- $configmap := lookup "v1" "ConfigMap" $.Values.namespace $configmapName }}
         {{- if $configmap }}
         configmap/{{ $configmapName }}/resourceVersion: {{ $configmapName }}/{{ $configmap.metadata.resourceVersion }}
         {{- $_ := set $processedConfigmaps $configmapName "" }}

--- a/charts/interop-eks-microservice-chart/templates/deployment.nodejs.yaml
+++ b/charts/interop-eks-microservice-chart/templates/deployment.nodejs.yaml
@@ -37,34 +37,32 @@ spec:
         {{- if .Values.deployment.image.digest }}
         digest: {{ .Values.deployment.image.digest | quote }} # Used to force deployment on same image version but different content
         {{- end }}
-        
-        # For each configmap and secret referenced by the deployment, execute a lookup to get the .metadata.resourceVersion field and store it in an annotation
-        # Lookup reference: https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-lookup-function
-        {{- $processedConfigmaps := dict }} # Map to store the processed configmaps
+
         {{- if .Values.deployment.envFromConfigmaps }}  
+        {{- $processedConfigmaps := dict }}
         {{- range $key, $val := .Values.deployment.envFromConfigmaps }}
         {{- $configmapAddress := mustRegexSplit "\\." $val 2 }}
         {{- $configmapName := index $configmapAddress 0 }}
-        {{- if not (hasKey $processedConfigmaps $configmapName) }}  # Check if the configmap has been processed yet
-        {{- $configmap := lookup "v1" "ConfigMap" $.Values.namespace $configmapName }}
+        {{- if not (hasKey $processedConfigmaps $configmapName) }}
+        {{- $configmap := lookup "v1" "ConfigMap" "dev-analytics" "common-redshift" }}
         {{- if $configmap }}
-        configmap/{{ $configmapName }}/resourceVersion: "{{ $configmapName }}/{{ $configmap.metadata.resourceVersion }}"
-        {{- $_ := set $processedConfigmaps $configmapName "" }}  # Set the configmap as processed
+        configmap/{{ $configmapName }}/resourceVersion: {{ $configmapName }}/{{ $configmap.metadata.resourceVersion }}
+        {{- $_ := set $processedConfigmaps $configmapName "" }}
         {{- end }}
         {{- end }}
         {{- end }}
         {{- end }}
         
-        {{- $processedSecrets := dict }} # Map to store the processed secrets
         {{- if .Values.deployment.envFromSecrets }}  
+        {{- $processedSecrets := dict }}
         {{- range $key, $val := .Values.deployment.envFromSecrets }}
         {{- $secretAddress := mustRegexSplit "\\." $val 2 }}
         {{- $secretName := index $secretAddress 0 }}
-        {{- if not (hasKey $processedSecrets $secretName) }}  # Check if the secret has been processed yet
+        {{- if not (hasKey $processedSecrets $secretName) }}
         {{- $secret := lookup "v1" "Secret" $.Values.namespace $secretName }}
         {{- if $secret }}
-        secret/{{ $secretName }}/resourceVersion: "{{ $secretName }}/{{ $secret.metadata.resourceVersion }}"
-        {{- $_ := set $processedSecrets $secretName "" }}  # Set the secret as processed
+        secret/{{ $secretName }}/resourceVersion: {{ $secretName }}/{{ $secret.metadata.resourceVersion }}
+        {{- $_ := set $processedSecrets $secretName "" }}
         {{- end }}
         {{- end }}
         {{- end }}

--- a/charts/interop-eks-microservice-chart/templates/deployment.nodejs.yaml
+++ b/charts/interop-eks-microservice-chart/templates/deployment.nodejs.yaml
@@ -44,7 +44,7 @@ spec:
         {{- $configmapAddress := mustRegexSplit "\\." $val 2 }}
         {{- $configmapName := index $configmapAddress 0 }}
         {{- if not (hasKey $processedConfigmaps $configmapName) }}
-        {{- $configmap := lookup "v1" "ConfigMap" "dev-analytics" "common-redshift" }}
+        {{- $configmap := lookup "v1" "ConfigMap" $.Values.namespace $secretName }}
         {{- if $configmap }}
         configmap/{{ $configmapName }}/resourceVersion: {{ $configmapName }}/{{ $configmap.metadata.resourceVersion }}
         {{- $_ := set $processedConfigmaps $configmapName "" }}

--- a/charts/interop-eks-microservice-chart/templates/deployment.nodejs.yaml
+++ b/charts/interop-eks-microservice-chart/templates/deployment.nodejs.yaml
@@ -54,6 +54,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        
         {{- $processedSecrets := dict }} # Map to store the processed secrets
         {{- if .Values.deployment.envFromSecrets }}  
         {{- range $key, $val := .Values.deployment.envFromSecrets }}

--- a/charts/interop-eks-microservice-chart/templates/deployment.nodejs.yaml
+++ b/charts/interop-eks-microservice-chart/templates/deployment.nodejs.yaml
@@ -37,6 +37,10 @@ spec:
         digest: {{ .Values.deployment.image.digest | quote }} # Used to force deployment on same image version but different content
         {{- end }}
 
+        {{- if and .Values.deployment .Values.deployment.configmapHash .Values.deployment.enableRolloutAnnotations }}
+        {{ .Values.name }}/configmap.hash: {{ .Values.deployment.configmapHash }} # This configmap has the same name as the deployment, while its hash value is stored in deployment.configmapHash
+        {{- end }}
+        
         {{- if and .Values.deployment .Values.deployment.envFromConfigmaps .Values.deployment.enableRolloutAnnotations }}  
         {{- $processedConfigmaps := dict }}
         {{- range $key, $val := .Values.deployment.envFromConfigmaps }}

--- a/charts/interop-eks-microservice-chart/templates/deployment.nodejs.yaml
+++ b/charts/interop-eks-microservice-chart/templates/deployment.nodejs.yaml
@@ -37,6 +37,31 @@ spec:
         {{- if .Values.deployment.image.digest }}
         digest: {{ .Values.deployment.image.digest | quote }} # Used to force deployment on same image version but different content
         {{- end }}
+        
+        # For each configmap and secret referenced by the deployment, execute a lookup to get the resourceVersion and store it in the annotation
+        # Lookup reference: https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-lookup-function
+        {{- if .Values.deployment.envFromConfigmaps }}
+          {{- range $key, $val := .Values.deployment.envFromConfigmaps }}
+            {{- $configmapAddress := mustRegexSplit "\\." $val 2 }}
+            {{- $configmapName := index $configmapAddress 0 }}
+            {{- $configmap := lookup "v1" "ConfigMap" $.Values.namespace $configmapName }}
+            {{- if $configmap }}
+            configmap/resourceVersion: "{{ $configmapName }}/{{ $configmap.metadata.resourceVersion }}"
+            {{- end }}
+          {{- end }}
+        {{- end }}
+
+        {{- if .Values.deployment.envFromSecrets }}
+          {{- range $key, $val := .Values.deployment.envFromSecrets }}
+            {{- $secretAddress := mustRegexSplit "\\." $val 2 }}
+            {{- $secretName := index $secretAddress 0 }}
+            {{- $secret := lookup "v1" "Secret" $.Values.namespace $secretName }}
+            {{- if $secret }}
+            secret/resourceVersion: "{{ $secretName }}/{{ $secret.metadata.resourceVersion }}"
+            {{- end }}
+          {{- end }}
+        {{- end }}
+
     spec:
       serviceAccountName: {{ .Values.name | quote }}
       {{- if and .Values.deployment .Values.deployment.preStopHookGracefulTermination .Values.deployment.preStopHookGracefulTermination.create }}

--- a/charts/interop-eks-microservice-chart/templates/deployment.nodejs.yaml
+++ b/charts/interop-eks-microservice-chart/templates/deployment.nodejs.yaml
@@ -38,7 +38,7 @@ spec:
         digest: {{ .Values.deployment.image.digest | quote }} # Used to force deployment on same image version but different content
         {{- end }}
 
-        {{- if and .Values.deployment .Values.deployment.envFromConfigmaps }}  
+        {{- if and .Values.deployment .Values.deployment.envFromConfigmaps .Values.deployment.enableRolloutAnnotations }}  
         {{- $processedConfigmaps := dict }}
         {{- range $key, $val := .Values.deployment.envFromConfigmaps }}
         {{- $configmapAddress := mustRegexSplit "\\." $val 2 }}
@@ -53,7 +53,7 @@ spec:
         {{- end }}
         {{- end }}
         
-        {{- if and .Values.deployment .Values.deployment.envFromSecrets }}  
+        {{- if and .Values.deployment .Values.deployment.envFromSecrets .Values.deployment.enableRolloutAnnotations }}  
         {{- $processedSecrets := dict }}
         {{- range $key, $val := .Values.deployment.envFromSecrets }}
         {{- $secretAddress := mustRegexSplit "\\." $val 2 }}

--- a/charts/interop-eks-microservice-chart/templates/deployment.yaml
+++ b/charts/interop-eks-microservice-chart/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
         {{- end }}
         {{- end }}
 
-        {{- if and .Values.deployment .Values.deployment.configmapHash .Values.deployment.enableRolloutAnnotations }}
+        {{- if and .Values.deployment .Values.deployment.enableRolloutAnnotations }}
         {{ .Values.name }}/configmap.sha256: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
 

--- a/charts/interop-eks-microservice-chart/values.yaml
+++ b/charts/interop-eks-microservice-chart/values.yaml
@@ -45,6 +45,8 @@ ingress:
  
 
 deployment:
+  # -- (bool) Enable annotation generation for referenced configmaps and secrets 
+  enableRolloutAnnotations: false
   # -- (int) Number of desired replicas for the service being deployed
   replicas: 
   # -- (object) Pod securityContext, applied to main container

--- a/charts/interop-eks-microservice-chart/values.yaml
+++ b/charts/interop-eks-microservice-chart/values.yaml
@@ -46,6 +46,8 @@ ingress:
 deployment:
   # -- (bool) Enable annotation generation for referenced configmaps and secrets 
   enableRolloutAnnotations: false
+  # -- (string) Hash of the related ConfigMap
+  configmapHash:
   # -- (int) Number of desired replicas for the service being deployed
   replicas: 
   # -- (object) Pod securityContext, applied to main container


### PR DESCRIPTION
This PR adds annotations to the deployment template for the deployment-related configmap (which has the same name as the deployment) and for each referenced configmap or secret.
These annotations help in forcing a rollout restart when a referenced configmap or secret is updated. 

Related PRs: 
- [#27](https://github.com/pagopa/interop-infra-commons/pull/27) on interop-infra-commons
- [#43](https://github.com/pagopa/interop-analytics-deployment/pull/43) on interop-analytics-deployment
