### PR TITLE
fix: allow setting imagePullPolicy on flyway init container

### DIFF
--- a/charts/interop-eks-microservice-chart/README.md
+++ b/charts/interop-eks-microservice-chart/README.md
@@ -33,6 +33,7 @@ The following table lists the configurable parameters of the Interop-eks-microse
 | deployment.flywayInitContainer.executeFlywayMigrate | bool | `true` | execute Flyway migrate command to apply migrations to the database |
 | deployment.flywayInitContainer.executeFlywayRepair | bool | `false` | execute Flyway repair command to recompute applied migrations metadata; useful for whitespace changes. |
 | deployment.flywayInitContainer.image.digest | string | `nil` | if set, overrides tag with the specified digest |
+| deployment.flywayInitContainer.image.imagePullPolicy | string | `nil` | Image pull policy for the init container; if unset, the Kubernetes default applies |
 | deployment.flywayInitContainer.image.repositoryName | string | `nil` | must be set if create is true, e.g. "interop-flyway-migrations" |
 | deployment.flywayInitContainer.image.repositoryPrefix | string | `nil` |  |
 | deployment.flywayInitContainer.image.tag | string | `nil` | defaults to deployment image tag if not set |

--- a/charts/interop-eks-microservice-chart/templates/deployment.yaml
+++ b/charts/interop-eks-microservice-chart/templates/deployment.yaml
@@ -118,6 +118,9 @@ spec:
       initContainers:
         - name: migrate-db
           image: "{{ $flyway_repository_prefix }}/{{ $flyway_repository_name }}{{ $flyway_image_tag }}{{ $flyway_image_digest }}"
+          {{- if .Values.deployment.flywayInitContainer.image.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.deployment.flywayInitContainer.image.imagePullPolicy }}
+          {{- end }}
           command:
             - /bin/sh
             - -c

--- a/charts/interop-eks-microservice-chart/values.yaml
+++ b/charts/interop-eks-microservice-chart/values.yaml
@@ -147,6 +147,8 @@ deployment:
       tag:
       # -- (string) if set, overrides tag with the specified digest
       digest:
+      # -- (string) Image pull policy for the init container; if unset, the Kubernetes default applies
+      imagePullPolicy:
     # -- (bool) execute Flyway migrate command to apply migrations to the database
     executeFlywayMigrate: true
     # -- (bool) execute Flyway repair command to recompute applied migrations metadata; useful for whitespace changes.


### PR DESCRIPTION
## Summary

- Add `deployment.flywayInitContainer.image.imagePullPolicy` to expose the init container's pull policy.
- The field is rendered on the `migrate-db` init container only when explicitly set; otherwise the Kubernetes default applies.
- No fallback to `deployment.image.imagePullPolicy`, to keep behavior unchanged for existing values files.

## Test plan

- [x] `helm template` with the existing `tests/flyway_custom_image_full/values.yaml` fixture — `imagePullPolicy` is omitted on the init container (no regression).
- [x] `helm template` with `--set deployment.flywayInitContainer.image.imagePullPolicy=IfNotPresent` — `imagePullPolicy: IfNotPresent` is rendered on the init container.
- [x] `helm-docs` regenerates `README.md` cleanly (pre-commit passes).
