### PR TITLE
fix: quote env values to preserve embedded special chars

### DIFF
--- a/charts/interop-eks-microservice-chart/templates/deployment.frontend.yaml
+++ b/charts/interop-eks-microservice-chart/templates/deployment.frontend.yaml
@@ -97,7 +97,7 @@ spec:
             {{- range $key, $val := .Values.deployment.env }}
             {{- $preprocessedEnvValue := include "interop-eks-microservice-chart.render-template" (dict "value" $val "context" $) }}
             - name: "{{ $key }}"
-              value: "{{ $preprocessedEnvValue }}"
+              value: {{ $preprocessedEnvValue | quote }}
             {{- end }}
             {{- end }}
             {{- if and .Values.deployment .Values.deployment.envFromConfigmaps }}

--- a/charts/interop-eks-microservice-chart/templates/deployment.yaml
+++ b/charts/interop-eks-microservice-chart/templates/deployment.yaml
@@ -150,7 +150,7 @@ spec:
             {{- range $key, $val := .Values.deployment.flywayInitContainer.env }}
             {{- $preprocessedEnvValue := include "interop-eks-microservice-chart.render-template" (dict "value" $val "context" $) }}
             - name: "{{ $key }}"
-              value: "{{ $preprocessedEnvValue }}"
+              value: {{ $preprocessedEnvValue | quote }}
             {{- end }}
             {{- end }}
             {{- if .Values.deployment.flywayInitContainer.envFromSecrets }}
@@ -249,7 +249,7 @@ spec:
             {{- range $key, $val := .Values.deployment.env }}
             {{- $preprocessedEnvValue := include "interop-eks-microservice-chart.render-template" (dict "value" $val "context" $) }}
             - name: "{{ $key }}"
-              value: "{{ $preprocessedEnvValue }}"
+              value: {{ $preprocessedEnvValue | quote }}
             {{- end }}
             {{- end }}
             {{- if and .Values.deployment .Values.deployment.envFromConfigmaps }}

--- a/tests/helm-unittest/deployment/deployment_env_quoting_test.yaml
+++ b/tests/helm-unittest/deployment/deployment_env_quoting_test.yaml
@@ -1,0 +1,22 @@
+suite: deployment env value quoting
+templates:
+  - templates/deployment.yaml
+values:
+  - ../common/base.yaml
+
+tests:
+  - it: preserves embedded double quotes in deployment.env values (e.g. JSON)
+    set:
+      deployment.env.TARGET_KNODE_URLS: '{"foo":"bar"}'
+      deployment.env.PLAIN: "hello"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TARGET_KNODE_URLS
+            value: '{"foo":"bar"}'
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PLAIN
+            value: hello

--- a/tests/helm-unittest/deployment/deployment_env_quoting_test.yaml
+++ b/tests/helm-unittest/deployment/deployment_env_quoting_test.yaml
@@ -7,16 +7,16 @@ values:
 tests:
   - it: preserves embedded double quotes in deployment.env values (e.g. JSON)
     set:
-      deployment.env.TARGET_KNODE_URLS: '{"foo":"bar"}'
-      deployment.env.PLAIN: "hello"
+      deployment.env.QUOTED_JSON: '{"key":"value"}'
+      deployment.env.PLAIN_STRING: "text"
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: TARGET_KNODE_URLS
-            value: '{"foo":"bar"}'
+            name: QUOTED_JSON
+            value: '{"key":"value"}'
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: PLAIN
-            value: hello
+            name: PLAIN_STRING
+            value: text

--- a/tests/helm-unittest/flyway/flyway_env_quoting_test.yaml
+++ b/tests/helm-unittest/flyway/flyway_env_quoting_test.yaml
@@ -1,0 +1,16 @@
+suite: flyway init container env value quoting
+templates:
+  - templates/deployment.yaml
+
+tests:
+  - it: preserves embedded double quotes in flywayInitContainer.env values
+    values:
+      - flyway_migrationpaths_single.yaml
+    set:
+      deployment.flywayInitContainer.env.QUOTED_JSON: '{"key":"value"}'
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: QUOTED_JSON
+            value: '{"key":"value"}'

--- a/tests/helm-unittest/frontend/frontend_env_quoting_test.yaml
+++ b/tests/helm-unittest/frontend/frontend_env_quoting_test.yaml
@@ -1,0 +1,17 @@
+suite: frontend deployment env value quoting
+templates:
+  - templates/deployment.frontend.yaml
+values:
+  - frontend.yaml
+
+tests:
+  - it: preserves embedded double quotes in deployment.env values for frontend
+    set:
+      deployment.enableRolloutAnnotations: false
+      deployment.env.QUOTED_JSON: '{"key":"value"}'
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: QUOTED_JSON
+            value: '{"key":"value"}'


### PR DESCRIPTION
## Summary

Env values written from `deployment.env`, `deployment.flywayInitContainer.env`, and the frontend `deployment.env` were emitted as:

```yaml
- name: "MY_KEY"
  value: "{{ $preprocessedEnvValue }}"
```

When the value contained a literal `"` (e.g. an inline JSON string), the embedded quotes broke the rendered deployment YAML:

```
Error: YAML parse error on interop-eks-microservice-chart/templates/deployment.yaml:
error converting YAML to JSON: yaml: line N: did not find expected key
```

This PR runs the value through Sprig `quote`, which wraps the string in double quotes and escapes any `"`, `\`, and newlines inside it:

```yaml
- name: "MY_KEY"
  value: {{ $preprocessedEnvValue | quote }}
```

The fix is applied at the three sites that share this pattern:

- `templates/deployment.yaml` — main container `deployment.env`
- `templates/deployment.yaml` — `deployment.flywayInitContainer.env`
- `templates/deployment.frontend.yaml` — frontend `deployment.env`

Behavior is unchanged for values that don't contain special characters; previously-broken values (JSON, paths with embedded quotes, etc.) now render correctly.

## Tests

Three new helm-unittest suites cover the three code paths, asserting that values with embedded double quotes round-trip into the rendered Deployment:

- `tests/helm-unittest/deployment/deployment_env_quoting_test.yaml`
- `tests/helm-unittest/flyway/flyway_env_quoting_test.yaml`
- `tests/helm-unittest/frontend/frontend_env_quoting_test.yaml`

These tests fail on `main` (YAML parse error) and pass with the fix.

## Test plan

- [x] `helm unittest --strict` all suites — 69 passed, 69 total
- [x] New regression suites fail without the fix, pass with it
- [x] No changes to `values.yaml` / schema; pre-commit `helm-docs` should be a no-op
