### PR TITLE
fix(deployment): quote annotation values to preserve string type

### DIFF
--- a/charts/interop-eks-microservice-chart/templates/deployment.yaml
+++ b/charts/interop-eks-microservice-chart/templates/deployment.yaml
@@ -69,7 +69,7 @@ metadata:
     {{- with .Values.deployment.metadata.annotations }}
     {{- range $key, $val := . -}}
     {{- $renderedVal := include "interop-eks-microservice-chart.render-template" (dict "value" $val "context" $) }}
-    {{ $key }}: {{ $renderedVal }}
+    {{ $key }}: {{ $renderedVal | quote }}
     {{- end }}
     {{- end }}
 spec:
@@ -102,7 +102,7 @@ spec:
         {{- with .Values.deployment.podTemplateMetadata.annotations }}
         {{- range $key, $val := . -}}
         {{- $renderedVal := include "interop-eks-microservice-chart.render-template" (dict "value" $val "context" $) }}
-        {{ $key }}: {{ $renderedVal }}
+        {{ $key }}: {{ $renderedVal | quote }}
         {{- end }}
         {{- end }}
 

--- a/tests/helm-unittest/deployment/deployment_annotation_quoting_test.yaml
+++ b/tests/helm-unittest/deployment/deployment_annotation_quoting_test.yaml
@@ -1,0 +1,34 @@
+suite: deployment annotation value quoting
+templates:
+  - templates/deployment.yaml
+values:
+  - ../common/base.yaml
+
+tests:
+  - it: renders Deployment metadata annotation values as strings, even when they look like YAML bools or numbers
+    set:
+      deployment.metadata.annotations:
+        example.com/bool-like: true
+        example.com/number-like: 42
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/bool-like"]
+          value: "true"
+      - equal:
+          path: metadata.annotations["example.com/number-like"]
+          value: "42"
+      - isKind:
+          of: Deployment
+
+  - it: renders pod template annotation values as strings, even when they look like YAML bools or numbers
+    set:
+      deployment.podTemplateMetadata.annotations:
+        example.com/bool-like: true
+        example.com/number-like: 42
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["example.com/bool-like"]
+          value: "true"
+      - equal:
+          path: spec.template.metadata.annotations["example.com/number-like"]
+          value: "42"


### PR DESCRIPTION
## Summary

The Deployment template renders user-supplied annotation values via `{{ $key }}: {{ $renderedVal }}`, without `| quote`. Because Kubernetes annotation values must be strings but YAML re-parses any bareword `true`/`false`/`42`/etc. as bool/int, this caused the K8s API server (and ArgoCD's tracking-info handler) to reject Deployments any time a user set an annotation whose value looked like a YAML boolean or number.

Concrete symptom that motivated this fix: adding `keel.sh/match-tag: "true"` to `deployment.metadata.annotations` in downstream values produced a rendered manifest with `keel.sh/match-tag: true` (bool), and ArgoCD failed manifest generation with:

```
.metadata.annotations accessor error: contains non-string value in the map under key "keel.sh/match-tag": true is of the type bool, expected string
```

The fix is a one-word change in two places (Deployment metadata + pod template metadata annotation blocks): render with `| quote`, matching how the chart already renders `deployment.image.digest` and how existing env-value rendering handles the same class of YAML-typing issue.

Backwards compatibility: `| quote` always produces a double-quoted string. Since K8s stores annotations as `map[string]string` regardless, existing users writing bareword annotation values were already getting string-coerced downstream by the API server — this change simply makes the coercion happen at Helm render time so ArgoCD (and any other strict YAML consumer) accepts the manifest.

## Test plan

- [x] New `helm-unittest` suite `deployment annotation value quoting` covering both the Deployment metadata block and the pod template metadata block, with YAML-bool (`true`) and numeric (`42`) values. Asserts each renders as the corresponding double-quoted string.
- [x] Full existing suite (27 suites, 93 tests) still passes.
