### PR TITLE
fix(frontend): render deployment.metadata.annotations on frontend Deployments

### DIFF
--- a/charts/interop-eks-microservice-chart/templates/deployment.frontend.yaml
+++ b/charts/interop-eks-microservice-chart/templates/deployment.frontend.yaml
@@ -23,6 +23,13 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     {{- include "interop-eks-microservice-chart.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.deployment.metadata.annotations }}
+    {{- range $key, $val := . -}}
+    {{- $renderedVal := include "interop-eks-microservice-chart.render-template" (dict "value" $val "context" $) }}
+    {{ $key }}: {{ $renderedVal | quote }}
+    {{- end }}
+    {{- end }}
 spec:
   replicas: {{ .Values.deployment.replicas }}
   selector:

--- a/tests/helm-unittest/frontend/frontend_annotation_quoting_test.yaml
+++ b/tests/helm-unittest/frontend/frontend_annotation_quoting_test.yaml
@@ -1,0 +1,19 @@
+suite: frontend deployment metadata annotation value quoting
+templates:
+  - templates/deployment.frontend.yaml
+values:
+  - frontend.yaml
+tests:
+  - it: renders Deployment metadata annotation values as strings, even when they look like YAML bools or numbers
+    set:
+      deployment.enableRolloutAnnotations: false
+      deployment.metadata.annotations:
+        example.com/bool-like: true
+        example.com/number-like: 42
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/bool-like"]
+          value: "true"
+      - equal:
+          path: metadata.annotations["example.com/number-like"]
+          value: "42"


### PR DESCRIPTION
## Summary

- `deployment.frontend.yaml` was missing the `annotations:` block under `metadata:`, so `deployment.metadata.annotations` values were silently dropped for `techStack: frontend` Deployments
- Added the same annotation rendering block already present in `deployment.yaml`, including `render-template` interpolation and `| quote` to preserve string types
- Added `tests/helm-unittest/frontend/frontend_annotation_quoting_test.yaml` to cover bool-like and number-like annotation values

## Test plan

- [x] Full `helm unittest` suite passes (94 tests, 28 suites)
- [ ] After merge and chart version bump, bump `targetRevision` in consuming appsets and confirm annotations appear on live frontend Deployments
